### PR TITLE
Avoid SyntaxWarning on Python >= 3.8

### DIFF
--- a/pages/createdialog.py
+++ b/pages/createdialog.py
@@ -110,7 +110,5 @@ class CreateDialog(QtWidgets.QDialog):
         self.monitor_edit.setText(task_tab.monitor_delay)
         self.error_edit.setText(task_tab.error_delay)
         self.price_edit.setText(task_tab.max_price)
-        self.maxprice_checkbox.setChecked(task_tab.max_price is not '')
+        self.maxprice_checkbox.setChecked(task_tab.max_price != '')
         self.addtask_btn.setText('Update Task')
-
-


### PR DESCRIPTION
Avoid [SyntaxWarnings on Python >= 3.8](https://docs.python.org/3/whatsnew/3.8.html#porting-to-python-3-8).

% `python3.8`
```
>>> "" is ""
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
```